### PR TITLE
add python3-pip

### DIFF
--- a/oracle9/oracle9noarch.lst
+++ b/oracle9/oracle9noarch.lst
@@ -215,6 +215,7 @@ python3-linux-procfs
 python3-louis
 python3-packaging
 python3-pexpect
+python3-pip
 python3-pip-wheel
 python3-ply
 python3-policycoreutils


### PR DESCRIPTION
needed to install lief module in order to run script to fix ldap salt for libvirt - saltstack issue 64962