### PR TITLE
Remove NetworkManager-l2tp-gnome from oracle9x86_64.lst

### DIFF
--- a/oracle9/oracle9x86_64.lst
+++ b/oracle9/oracle9x86_64.lst
@@ -684,7 +684,6 @@ net-tools
 NetworkManager
 NetworkManager-adsl
 NetworkManager-bluetooth
-NetworkManager-l2tp-gnome
 NetworkManager-libnm
 NetworkManager-libreswan-gnome
 NetworkManager-openconnect-gnome


### PR DESCRIPTION
Removed 'NetworkManager-l2tp-gnome' from the list.